### PR TITLE
Set dnsmasq to start on CDSW node reboot

### DIFF
--- a/scripts/cdsw-secure-cluster/instance-postcreate-cdsw.sh
+++ b/scripts/cdsw-secure-cluster/instance-postcreate-cdsw.sh
@@ -19,6 +19,7 @@ yum -y install dnsmasq
 cat /etc/resolv.conf | grep nameserver > /etc/dnsmasq.resolv.conf
 perl -pi -e "s|^.*?resolv-file.*?$|resolv-file=/etc/dnsmasq.resolv.conf|" /etc/dnsmasq.conf
 systemctl start dnsmasq
+systemctl enable dnsmasq
 
 # Add DNS(dnsmasq on local)
 perl -pi -e "s/nameserver.*$/nameserver $(hostname -i)/" /etc/resolv.conf


### PR DESCRIPTION
I found that if dnsmasq doesn't start when the CDSW node reboots then CDSW will not work.