### PR TITLE
Moved mountAllUnmountedDisks to CDSW Section

### DIFF
--- a/cdsw-secure-cluster.conf
+++ b/cdsw-secure-cluster.conf
@@ -31,12 +31,6 @@ common-instance-properties {
     tags {
         owner: ${?INSTANCE_OWNER_TAG}
     }
-
-    # Turning off mountAllUnmountedDisks is necessary for CDSW to work, as CDSW handles
-    # this step on its own
-    normalizationConfig {
-        mountAllUnmountedDisks: false
-    }
 }
 
 cloudera-manager {
@@ -252,6 +246,13 @@ cluster {
     cdsw {
         count: 1
         instance: ${common-instance-properties} {
+	
+            # Turning off mountAllUnmountedDisks is necessary for CDSW to work, as CDSW handles
+            # this step on its own
+            normalizationConfig {
+                mountAllUnmountedDisks: false
+            }
+	    
             type: ${INSTANCE_TYPE_CDSW}
             instanceNamePrefix: ${?INSTANCE_NAME_PREFIX}"-cdsw"
             tags {


### PR DESCRIPTION
Only the CDSW needs to have the mountAllUnmountedDisks section set to false.  It is beneficial to have the worker nodes still mount disks automatically.