### PR TITLE
Add gcp support (base cluster only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 six.pyc
 __pycache__/
 your-aws-info.conf
+your-gcp-info.conf

--- a/c5-base-cluster.conf
+++ b/c5-base-cluster.conf
@@ -1,33 +1,10 @@
 include file("your-aws-info.conf")
 
-## Instance Configurations
-INSTANCE_TYPE_CM:        t2.xlarge    #vCPU 4, RAM 16G
-INSTANCE_TYPE_MASTER:    t2.large     #vCPU 2, RAM 8G
-INSTANCE_TYPE_WORKER:    t2.large     #vCPU 2, RAM 8G
-INSTANCE_TYPE_KAFKA:     t2.large     #vCPU 2, RAM 8G
-
-WORKER_NODE_NUM:         3            #Number of Worker Nodes
-##
-
 name: c5-base-cluster
 
-provider {
-    type: aws
-    accessKeyId: ${?AWS_ACCESS_KEY_ID}
-    secretAccessKey: ${?AWS_SECRET_ACCESS_KEY}
-    region: ${?AWS_REGION}
-    subnetId: ${?AWS_SUBNET_ID}
-    securityGroupsIds: ${?AWS_SECURITY_GROUP}
-}
 ssh {
     username: ${?OS_USERNAME}
     privateKey: ${?KEY_PAIR}
-}
-common-instance-properties {
-    image: ${?AWS_AMI}
-    tags {
-        owner: ${?INSTANCE_OWNER_TAG}
-    }
 }
 
 cloudera-manager {
@@ -164,12 +141,6 @@ cluster {
                 group: worker
             }
             
-            # Disks are automatically mounted by Cloudera Director
-            # /data0, /data1, /data2 ...
-            ebsVolumeCount : 4
-	        ebsVolumeType: gp2
-	        ebsVolumeSizeGiB: 50
-
             bootstrapScriptsPaths: [
                 "scripts/common/bootstrap-common.sh",
                 "scripts/base-cluster/bootstrap-worker-init.sh"

--- a/c6-base-cluster.conf
+++ b/c6-base-cluster.conf
@@ -1,4 +1,4 @@
-include file("your-gcp-info.conf")
+include file("your-aws-info.conf")
 
 name: c6-base-cluster
 
@@ -127,7 +127,7 @@ cluster {
 
     worker {
         count: ${?WORKER_NODE_NUM}
-        minCount: ${?WORKER_NODE_NUM}
+        #minCount: ${?WORKER_NODE_NUM}
         instance: ${common-instance-properties} {
             type: ${INSTANCE_TYPE_WORKER}
             instanceNamePrefix: ${?INSTANCE_NAME_PREFIX}"-worker"

--- a/c6-base-cluster.conf
+++ b/c6-base-cluster.conf
@@ -1,33 +1,10 @@
-include file("your-aws-info.conf")
-
-## Instance Configurations
-INSTANCE_TYPE_CM:        t2.xlarge    #vCPU 4, RAM 16G
-INSTANCE_TYPE_MASTER:    t2.large     #vCPU 2, RAM 8G
-INSTANCE_TYPE_WORKER:    t2.large     #vCPU 2, RAM 8G
-INSTANCE_TYPE_KAFKA:     t2.large     #vCPU 2, RAM 8G
-
-WORKER_NODE_NUM:         3            #Number of Worker Nodes
-##
+include file("your-gcp-info.conf")
 
 name: c6-base-cluster
 
-provider {
-    type: aws
-    accessKeyId: ${?AWS_ACCESS_KEY_ID}
-    secretAccessKey: ${?AWS_SECRET_ACCESS_KEY}
-    region: ${?AWS_REGION}
-    subnetId: ${?AWS_SUBNET_ID}
-    securityGroupsIds: ${?AWS_SECURITY_GROUP}
-}
 ssh {
     username: ${?OS_USERNAME}
     privateKey: ${?KEY_PAIR}
-}
-common-instance-properties {
-    image: ${?AWS_AMI}
-    tags {
-        owner: ${?INSTANCE_OWNER_TAG}
-    }
 }
 
 cloudera-manager {
@@ -158,12 +135,6 @@ cluster {
                 group: worker
             }
             
-            # Disks are automatically mounted by Cloudera Director
-            # /data0, /data1, /data2 ...
-            ebsVolumeCount : 4
-	        ebsVolumeType: gp2
-	        ebsVolumeSizeGiB: 50
-
             bootstrapScriptsPaths: [
                 "scripts/common/bootstrap-common.sh",
                 "scripts/common/c6/bootstrap-common.sh"

--- a/c6-cdsw-secure-cluster.conf
+++ b/c6-cdsw-secure-cluster.conf
@@ -4,7 +4,6 @@ include file("c6-secure-cluster.conf")
 
 name: c6-cdsw-secure-cluster
 
-INSTANCE_TYPE_CDSW:      t2.2xlarge   #vCPU 8, RAM 32G
 CDSW_DOCKER_VOLUME_NUM:  3    
 CDSW_DOCKER_VOLUME_GB:   200
 
@@ -62,6 +61,11 @@ cluster {
 	        ebsVolumeCount : ${CDSW_DOCKER_VOLUME_NUM}
 	        ebsVolumeType: gp2
 	        ebsVolumeSizeGiB: ${CDSW_DOCKER_VOLUME_GB}
+
+            dataDiskCount: ${CDSW_DOCKER_VOLUME_NUM}
+            dataDiskType: LocalSSD
+            localSSDInterfaceType: NVMe
+
 
             bootstrapScriptsPaths: [
                 "scripts/common/bootstrap-common.sh",

--- a/scripts/common/bootstrap-common.sh
+++ b/scripts/common/bootstrap-common.sh
@@ -15,17 +15,18 @@ rpm -ivh "http://archive.cloudera.com/director6/6.0.0/redhat7/RPMS/x86_64/oracle
 
 #Use ntpd instead of chrony
 #And Use Amazon Time Sync Service mainly - https://docs.aws.amazon.com/ja_jp/AWSEC2/latest/UserGuide/set-time.html
-yum erase -y chrony
-yum install -y ntp
-cat /etc/ntp.conf
-sed -i -e '/^server/d' /etc/ntp.conf
-echo "server 169.254.169.123 prefer iburst" >> /etc/ntp.conf
-#echo "server time.google.com iburst" >> /etc/ntp.conf
-cat /etc/ntp.conf
+yum erase -y ntp
+yum install -y chrony
+sed -i -e '/^server/d' /etc/chrony.conf
+echo "server 169.254.169.123 prefer iburst" >> /etc/chrony.conf
+echo "server 169.254.169.254 iburst" >> /etc/chrony.conf
+echo "server time.google.com iburst" >> /etc/chrony.conf
+cat /etc/chrony.conf
 service ntpd stop
-service ntpd start
-service ntpd status
-chkconfig ntpd on
-ntptime
-ntpq -p
-ntpq -n -c opeers
+systemctl stop chronyd
+systemctl start chronyd
+systemctl status chronyd
+
+chronyc tracking
+chronyc sources
+chronyc sourcestats

--- a/scripts/secure-cluster/bootstrap-common-configure-network.sh
+++ b/scripts/secure-cluster/bootstrap-common-configure-network.sh
@@ -18,21 +18,28 @@ if [ -e /root/cm ]; then
     internal_fqdn_suffix=$(hostname -d)
     hostname=$(hostname -s)
     internal_ip=$(hostname -i)
-    netowrk_cidr=$(ipcalc -np "$(ip -o -f inet addr show | awk '/scope global/ {print $4}')" | awk '{getline x;print x;}1' | awk -F= '{print $2}' | awk 'NR%2{printf "%s/",$0;next;}1')
+    netowrk_cidr=$(ip -o -f inet addr show | awk '/scope global/ {print $4}')
     
     # Add KDC hostname
     echo "${internal_ip}    ${hostname}.${internal_fqdn_suffix} ${hostname} ${kerberos_hostname}.${internal_fqdn_suffix} ${kerberos_hostname}" >> /etc/hosts
 else
     # Looking for the CM node 
-    netowrk_cidr=$(ipcalc -np "$(ip -o -f inet addr show | awk '/scope global/ {print $4}')" | awk '{getline x;print x;}1' | awk -F= '{print $2}' | awk 'NR%2{printf "%s/",$0;next;}1')
+    netowrk_cidr=$(ip -o -f inet addr show | awk '/scope global/ {print $4}') 
+    cidr_prefix_length=$(ip -o -f inet addr show | awk '/scope global/ {print $4}' | awk -F'/' '{print $2}') 
+
+    if [ "${cidr_prefix_length}" -eq 32 ]; then #GCP
+        network_addr=$(ip -o -f inet addr show | awk '/scope global/ {print $4}' | awk -F'/' '{print $1}')
+        netowrk_cidr="${network_addr}/20" #/20 is default of GCP
+    fi
+    echo ${netowrk_cidr}
     
     for i in `seq 30` : # 30*10sec -> 5min
     do
-        cm_ip=$(nmap -sT -p7 ${netowrk_cidr} | grep -B 3 open | grep "ip-" | awk -F[\(\)] '{print $2}')
+        cm_fqdn=$(nmap -sT -p7 ${netowrk_cidr} | grep -B 3 open | grep "Nmap scan report for" | awk '{print $5}')
 
-        if [ -n "${cm_ip}" ]; then
+        if [ -n "${cm_fqdn}" ]; then
             echo "CM node found."
-            cm_fqdn=$(host ${cm_ip} | awk '{print $5}')
+            cm_ip=$(host ${cm_fqdn} | awk '{print $4}')
             cm_hostname=$(echo ${cm_fqdn} | awk -F. '{print $1}')
             internal_fqdn_suffix=$(hostname -d)
     

--- a/your-aws-info.conf.template
+++ b/your-aws-info.conf.template
@@ -38,4 +38,7 @@ common-instance-properties {
     tags {
         owner: ${?INSTANCE_OWNER_TAG}
     }
+    ebsVolumeCount : 4
+	ebsVolumeType: gp2
+	ebsVolumeSizeGiB: 100
 }

--- a/your-aws-info.conf.template
+++ b/your-aws-info.conf.template
@@ -1,15 +1,41 @@
+## Your AWS information
 AWS_REGION:            ap-xxxxxxxxx-1          #Your AWS region
 AWS_SUBNET_ID:         subnet-xxxxxxx          #Your Subnet ID
 AWS_SECURITY_GROUP:    sg-xxxxxxxx             #Your Security Group
-KEY_PAIR:              your-keypair-on-aws.pem #Your AWS Keypair, Set /full/path/to/your-keypair-on-aws.pem
 
 OS_USERNAME:           centos                  #OS Super user (e.g. centos, ec2-user)
+KEY_PAIR:              your-keypair-on-aws.pem #Your AWS Keypair, Set /full/path/to/your-keypair-on-aws.pem
 AWS_AMI:               ami-xxxxxxxx            #An CentOS7/RHEL7 AMI on Your AWS Region (e.g. ami-25bd2743 is CentOS 7.4 on Tokyo region)
                                                #AMI ids are different depending on the regions, please check your region - https://wiki.centos.org/Cloud/AWS
                                                #Note: Some scripts depend on CentOS7/RHEL7 os command and I only tested on CentOS 7.4
 
-INSTANCE_NAME_PREFIX:  cdsw-demo               #Prefix of ec2 instance name
+## Instance Configurations
+INSTANCE_TYPE_CM:        m5.xlarge    #vCPU 4, RAM 16G
+INSTANCE_TYPE_MASTER:    m5.large     #vCPU 2, RAM 8G
+INSTANCE_TYPE_WORKER:    m5.large     #vCPU 2, RAM 8G
+INSTANCE_TYPE_GW:        m5.large     #vCPU 2, RAM 8G
+INSTANCE_TYPE_CDSW:      m5.xlarge    #vCPU 4, RAM 16G
+INSTANCE_TYPE_KAFKA:     m5.large     #vCPU 2, RAM 8G
+
+# Optional settings
+WORKER_NODE_NUM:         3            #Number of Worker Nodes
+INSTANCE_NAME_PREFIX:  cdsw-demo      #Prefix of instance name
+INSTANCE_OWNER_TAG:    your_name       #"owner" tag of incetances
 
 
-# Optional - Ignore these fields if you don't need.
-INSTANCE_OWNER_TAG:    your_name               #"owner" tag of ec2 incetance
+### AWS Provider - DO NOT CHANGE THIS SECTION ###
+provider {
+    type: aws
+    accessKeyId: ${?AWS_ACCESS_KEY_ID}
+    secretAccessKey: ${?AWS_SECRET_ACCESS_KEY}
+    region: ${?AWS_REGION}
+    subnetId: ${?AWS_SUBNET_ID}
+    securityGroupsIds: ${?AWS_SECURITY_GROUP}
+}
+
+common-instance-properties {
+    image: ${?AWS_AMI}
+    tags {
+        owner: ${?INSTANCE_OWNER_TAG}
+    }
+}

--- a/your-gcp-info.conf.template
+++ b/your-gcp-info.conf.template
@@ -1,0 +1,46 @@
+## Your GCP information
+GCP_PROJECT_ID:        your-project-id         #Your GCP Project ID
+GCP_REGION:            asia-northeast1         #Your GCP reegion
+GCP_ZONE:              asia-northeast1-c       #Your GCP zone
+GCP_VPC_NETWORK:       your-network            #Your GCP network
+GCP_VPC_SUBNET:        your-subnet             #Your GCP subnet
+
+OS_USERNAME:           yourname                #OS Super user (e.g. centos, ec2-user)
+KEY_PAIR:              your-keypair-on-gcp.pem  #SSH Private key, Set /full/path/to/your-private-key.pem
+GCP_OS_IMAGE:          "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20180815"  #An CentOS7 OS image on GCP
+
+## Instance Configurations
+INSTANCE_TYPE_CM:        n1-standard-4     #vCPU 4, RAM 15G
+INSTANCE_TYPE_MASTER:    n1-standard-2     #vCPU 2, RAM 7.5G
+INSTANCE_TYPE_WORKER:    n1-standard-2     #vCPU 2, RAM 7.5G
+INSTANCE_TYPE_GW:        n1-standard-2     #vCPU 2, RAM 7.5G
+INSTANCE_TYPE_CDSW:      n1-standard-4     #vCPU 4, RAM 15G
+INSTANCE_TYPE_KAFKA:     n1-standard-2     #vCPU 2, RAM 7.5G
+
+# Optional settings
+WORKER_NODE_NUM:         3            #Number of Worker Nodes
+INSTANCE_NAME_PREFIX:  cdsw-demo      #Prefix of instance name
+INSTANCE_OWNER_TAG:    your_name       #"owner" tag of incetances
+
+
+### GCP Provider - DO NOT CHANGE THIS SECTION ###
+provider {
+    type: google
+    projectId: ${?GCP_PROJECT_ID}
+    region: ${?GCP_REGION}
+    jsonKey: ${?GCP_JSON_KEY}
+    instanceNamePrefix: ${?INSTANCE_NAME_PREFIX}
+}
+
+common-instance-properties {
+    image: ${?GCP_OS_IMAGE}
+    networkName: ${?GCP_VPC_NETWORK}
+    subnetworkName: ${GCP_VPC_SUBNET}
+    region: ${?GCP_REGION}
+    zone: ${?GCP_ZONE}
+    dataDiskCount: 0
+
+    tags {
+        owner: ${?INSTANCE_OWNER_TAG}
+    }
+}


### PR DESCRIPTION
Currently only for deploying a non-secure cluster. 
Because Cloudera Director uses UUID for the hostname of cluster nodes, kerberize cluster failed due to long FQDN.